### PR TITLE
Fix/navigate to log details

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -21,7 +21,11 @@ Having AWS credentials on your local machine is required to use SST.
 You can see the [steps required to add AWS credentials here.](/docs/aws_setup.md)
 
 If you completed these steps correctly, you should be able to run `aws sts get-caller-identity --profile <aws_iam_access_key_profile_name>` and see your AWS account ID.
-### 3. Build Next.js app into Lambdas and deploy them locally
+
+### 3. Add database URI to .env
+It should look like this, with `?pgbouncer=true` at the end ([see issue](https://github.com/prisma/prisma/issues/11643#issuecomment-1034078942)):
+`DATABASE_URL=<your_database_uri>?pgbouncer=true`
+### 4. Build Next.js app into Lambdas and deploy them locally
 
 - `yarn sst dev --profile <aws_iam_access_key_profile_name> --stage <your_name>-dev` to start the Live Lambda Development environment.
   - This command does the following:
@@ -29,7 +33,7 @@ If you completed these steps correctly, you should be able to run `aws sts get-c
     - Builds the Next.js app into lambda functions, 
     - and deploys them to the local Lambda environment
 
-### 4. Bind Next.js app to local Lambda environment so that it can invoke AWS resources
+### 5. Bind Next.js app to local Lambda environment so that it can invoke AWS resources
 
 - `yarn dev --profile <aws_iam_access_key_profile_name> --stage <your_name>-dev` to bind the Next.js app to sst, which allows it to invoke AWS resources.
   - This command does the following:

--- a/front/README.md
+++ b/front/README.md
@@ -20,10 +20,10 @@ Having AWS credentials on your local machine is required to use SST.
 
 You can see the [steps required to add AWS credentials here.](/docs/aws_setup.md)
 
-If you completed these steps correctly, you should be able to run `aws sts get-caller-identity --profile aws_iam_access_key_profile_name` and see your AWS account ID.
+If you completed these steps correctly, you should be able to run `aws sts get-caller-identity --profile <aws_iam_access_key_profile_name>` and see your AWS account ID.
 ### 3. Build Next.js app into Lambdas and deploy them locally
 
-- `npx sst dev --profile aws_iam_access_key_profile_name` to start the Live Lambda Development environment.
+- `yarn sst dev --profile <aws_iam_access_key_profile_name> --stage <your_name>-dev` to start the Live Lambda Development environment.
   - This command does the following:
     - Starts a local Lambda environment
     - Builds the Next.js app into lambda functions, 
@@ -31,8 +31,10 @@ If you completed these steps correctly, you should be able to run `aws sts get-c
 
 ### 4. Bind Next.js app to local Lambda environment so that it can invoke AWS resources
 
-- `yarn dev --profile aws_iam_access_key_profile_name` to bind the Next.js app to sst, which allows it to invoke AWS resources.
+- `yarn dev --profile <aws_iam_access_key_profile_name> --stage <your_name>-dev` to bind the Next.js app to sst, which allows it to invoke AWS resources.
   - This command does the following:
     - Starts the Next.js app at localhost
     - Binds the Next.js app to the local Lambda environment (therefore allowing it to use AWS resources)
 
+## Deploying to staging
+- `yarn sst deploy --profile <aws_iam_access_key_profile_name> --stage staging`

--- a/front/prisma/schema.prisma
+++ b/front/prisma/schema.prisma
@@ -3,6 +3,7 @@
 generator client {
   provider = "prisma-client-js"
   previewFeatures = ["jsonProtocol"]
+  binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
 }
 
 datasource db {

--- a/front/prisma/schema.prisma
+++ b/front/prisma/schema.prisma
@@ -2,7 +2,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["jsonProtocol"]
   binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
 }
 

--- a/front/src/app/EmptyLogs.tsx
+++ b/front/src/app/EmptyLogs.tsx
@@ -4,7 +4,16 @@ import Link from "next/link";
 export default function EmptyLogs() {
     return (
         <CardAtom>
-            <p className="px-4 py-2 text-gray-800 text-center">There are no logs yet. Please connect our SDK and start logging!  <Link className="underline" href="https://github.com/Theodo-UK/OmniLog/blob/main/README.md#quickstart">For more info, see here</Link>. </p>
+            <p className="px-4 py-2 text-gray-800 text-center">
+                There are no logs yet. Please connect our SDK and start logging!{" "}
+                <Link
+                    className="underline"
+                    href="https://github.com/Theodo-UK/OmniLog/blob/main/README.md#quickstart"
+                >
+                    For more info, see here
+                </Link>
+                .{" "}
+            </p>
         </CardAtom>
     );
 }

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -5,8 +5,8 @@ import LogsTable from "./LogsTable";
 export default async function Home() {
     const logs = await LogsData.getLogs();
 
-    if(logs.length === 0) {
-      return <EmptyLogs/>
+    if (logs.length === 0) {
+        return <EmptyLogs />;
     }
 
     return <LogsTable logs={logs} />;


### PR DESCRIPTION
**🧾 Fix Summary 🧾 **
Problem
- Prisma Client was running in local dev but not on staging

Explanation
- The Prisma Client has several Rust engines which are in the form of executable files
- These files are platform dependent (macOS, linux)
- The Prisma Client was working before because the "native" target is turned on by default (which builds the engine files for local dev)
- The Prisma Client was not working when deployed to staging because AWS Lambda uses linux-arm64
- [Reference](https://www.prisma.io/docs/concepts/components/prisma-schema/generators#binary-targets) 

Fix
- Add linux-arm64-openssl-1.0.x as binary target
----
Bug ticket
- [Timebox 1](https://trello.com/c/67xvhkvN/90-1-timebox-1hr-x-1dev-bug-navigating-to-logs-in-staging-throws-an-error)
- [Timebox 2](https://trello.com/c/E9EorFXT/89-2-timebox-2hr-x-1dev-bug-navigating-to-logs-in-staging-throws-an-error-2)

Approaches
- Tried to old stages, and redeployed. Same error.
- Tried to move data folder to app folder. Same error.
  - 🐞 Found **new** ConnectorError bug in local (see below) when trying to redeploy to staging `yarn sst deploy --profile ___ --stage staging`
    - 🔨 Fixed by adding pgbouncer=true to DATABASE_URL DATABASE_URL=<omitted_url>?pgbouncer=true
    - Checked if original error was still happening. Yes, same error.
- 🐞 Checked AWS > Lambda > Functions > Next.js server (staging-front-Site-siteServerFunction6DFA6F1B-0mjKEzRsdWZ6) > Monitor > Logs > LogStream  and **found PrismaClientInitializationError** (see below) 
  - 🔨 Fixed by adding `binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]`



---
ConnectorError bug:
  ```
  ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42P05), message: "prepared statement \"s0\" already exists", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("prepare.c"), line: Some(412), routine: Some("StorePreparedStatement") }) }), transient: false })
  ```
---
PrismaClientInitializationError: 
```
2023-08-17T14:30:10.925Z	07b77318-851f-4375-9ed6-c69e7974361c	ERROR	PrismaClientInitializationError: 
Invalid `prisma.llm_logs.findUnique()` invocation:


Prisma Client could not locate the Query Engine for runtime "linux-arm64-openssl-1.0.x".

This happened because Prisma Client was generated for "darwin", but the actual deployment required "linux-arm64-openssl-1.0.x".
Add "linux-arm64-openssl-1.0.x" to `binaryTargets` in the "schema.prisma" file and run `prisma generate` after saving it:

generator client {
  provider      = "prisma-client-js"
  binaryTargets = ["native", "linux-arm64-openssl-1.0.x"]
}

The following locations have been searched:
  /var/task/node_modules/.prisma/client
  /var/task/node_modules/@prisma/client
  /Users/justinkek/Desktop/Repositories/theodo/OmniLog/front/node_modules/@prisma/client
  /tmp/prisma-engines
    at Hr.handleRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:122:7272)
    at Hr.handleAndLogRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:122:6388)
    at Hr.request (/var/task/node_modules/@prisma/client/runtime/library.js:122:6108)
    at async l (/var/task/node_modules/@prisma/client/runtime/library.js:126:10298)
    at async Object.getLogDetails (/var/task/.next/server/chunks/65.js:111:21)
    at async LogDetails (/var/task/.next/server/app/logs/[id]/page.js:312:24) {
  clientVersion: '5.1.1',
  errorCode: undefined
}

```
    
 