### PR TITLE
chore: remove GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # OmniLog 
 
-![Staging CD](https://github.com/Theodo-UK/OmniLog/actions/workflows/cd.yml/badge.svg)
-
 ## Understand your LLM prompts, Empowered by Generative AI
 
 <div align="center">


### PR DESCRIPTION
remove the badge because it takes a while to update and can be misleading - we should rely on the built in flow indicator next to commits instead 

![image](https://github.com/Theodo-UK/OmniLog/assets/57725347/846922ba-456e-4dba-9e39-4b3403224b0b)
