### PR TITLE
Fix/nextauth invalid nextjs route

### DIFF
--- a/front/src/app/api/auth/[...nextauth]/route.ts
+++ b/front/src/app/api/auth/[...nextauth]/route.ts
@@ -3,7 +3,7 @@ import { compare } from "bcrypt";
 import NextAuth, { type NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 
-export const authOptions: NextAuthOptions = {
+const authOptions: NextAuthOptions = {
     session: {
         strategy: "jwt",
     },

--- a/front/src/services/LogsData.ts
+++ b/front/src/services/LogsData.ts
@@ -15,7 +15,7 @@ export const LogsData = {
     getLogDetails: async (id: string): Promise<llm_logs> => {
         const log = await prisma.llm_logs.findUnique({
             where: {
-                id: parseInt(id),
+                id,
             },
         });
 


### PR DESCRIPTION
Fix for: 
- https://github.com/Theodo-UK/OmniLog/actions/runs/6039579849/job/16388543124
- and Type error: Type 'number' is not assignable to type 'string'. for id in llm_logs (caught during deploy)

Fix from: 
https://github.com/vercel/next.js/discussions/50511#discussioncomment-6245204

Cause: unknown, possibly regex issue on the backend 
https://github.com/nextauthjs/next-auth/issues/6792#issuecomment-1586257837

If need to export authOptions to multiple files in the future, follow solution here: https://github.com/vercel/next.js/issues/50870#issuecomment-1598655396