### PR TITLE
feat(front): add tags to log details page

### DIFF
--- a/front/src/features/tables/LogDetailsTable.tsx
+++ b/front/src/features/tables/LogDetailsTable.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/atoms/Button";
 import { CardAtom } from "@/components/atoms/CardAtom";
 import { useNavigation } from "@/hooks/useNavigation";
 import { LogData } from "@/types/logDisplayOptions";
+import { ColumnContentTags } from "./components/ColumnContentTags";
 
 export const LogDetailsTable = ({ logDetails }: { logDetails: LogData }) => {
     const cost_text: string =
@@ -51,6 +52,10 @@ export const LogDetailsTable = ({ logDetails }: { logDetails: LogData }) => {
                             Estimated cost (USD)
                         </td>
                         <td className="px-4 py-2">{cost_text}</td>
+                    </tr>
+                    <tr>
+                        <td className="font-bold px-4 py-2">Tags</td>
+                        <ColumnContentTags tags={logDetails.tags} />
                     </tr>
                 </tbody>
             </table>

--- a/front/src/services/LogsData.ts
+++ b/front/src/services/LogsData.ts
@@ -28,7 +28,11 @@ export const LogsData = {
                 id,
             },
             include: {
-                tags: true,
+                tags: {
+                    orderBy: {
+                        name: "asc",
+                    },
+                },
             },
         });
 


### PR DESCRIPTION
https://trello.com/c/QkQCse5S/128-2-aauser-on-the-log-details-page-i-can-see-tags-bound-to-a-log-entry

<img width="1510" alt="image" src="https://github.com/Theodo-UK/OmniLog/assets/129053466/b979596e-a45a-45d3-8332-9136880ff9e4">
